### PR TITLE
Fixed a typo and removed a misplaced exit warning

### DIFF
--- a/script-utils/latest/Murata_Wireless_Yocto_Build_CYW.sh
+++ b/script-utils/latest/Murata_Wireless_Yocto_Build_CYW.sh
@@ -238,7 +238,6 @@ if [ "$PROCEED_UPDATE_OPTION" = "y" ] || [ "$PROCEED_UPDATE_OPTION" = "Y" ] || [
 else
 	echo " "
 	echo -e "${RED}Murata: Skipping repo tool installation"
-	echo -e "Exiting script.....${NC}"
 fi
 
 # Ubuntu Distro and Version verified. Now add necessary commands.
@@ -2252,7 +2251,7 @@ read BUILD_DIR_NAME
 		echo "   (a) Execute the following command from BSP directory:"
 		echo "       $ source setup-environment $BUILD_DIR_NAME"
 		echo "   (b) Execute the following command from $BUILD_DIR_NAME directory:"
-		echo "       $ bitbake fsl-imaga-validation-imx"
+		echo "       $ bitbake fsl-image-validation-imx"
 		echo " "
 		read -p "Select which entry 1 or 2? " DIR_OPTION
 		if [ "$DIR_OPTION" = "2" ]; then


### PR DESCRIPTION
1. corrected typo `bitbake fsl-imaga-validation-imx` to `bitbake fsl-image-validation-imx`.
2. If repo tool installation is skipped, the script is actually not exiting. So, the `"Exiting script...."` echo is removed.