### PR TITLE
imx-kirkstone-godzilla: Use correct branch and latest revision from cyw-fmac repo

### DIFF
--- a/recipes-kernel/backporttool-linux/backporttool-linux_1.0.bb
+++ b/recipes-kernel/backporttool-linux/backporttool-linux_1.0.bb
@@ -10,12 +10,12 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 SRC_URI =  " \
-    git://github.com/murata-wireless/cyw-fmac;protocol=http;branch=imx-langdale-godzilla \
+    git://github.com/murata-wireless/cyw-fmac;protocol=http;branch=imx-kirkstone-godzilla \
     file://0004-makefile-yacc-flex-update.patch;apply=yes \
     file://0003-kernel_change_for_fmac_log_string.patch;apply=yes \
 "
 
-SRCREV = "dadb79aca9840bb182bef9753f4c47f067269dd9"
+SRCREV = "d23cd1725e9cd3b1d0518f47a2cae4bcd8c62c92"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
While in the progress of upgrading our system to kirkstone, I was looking at the changes between fafnir and godzilla, and noticed that backporttool on the `imx-kirkstone-godzilla` branch points to the langdale branch (this doesn't really cause any issues as it's the same commit), but also that [two newer patches](https://github.com/murata-wireless/cyw-fmac/commits/imx-kirkstone-godzilla/) ("Godzilla 3.0") are available on that branch. 

Is it intentional that those are left out, or should it have been included in the imx-kirkstone-godzilla release as well? 
We just want to make sure we have the latest and greatest firmware when building our upgraded image! :)